### PR TITLE
net-analyzer/speedtest-cli - add setuptools dependency (bug# 502302)

### DIFF
--- a/net-analyzer/speedtest-cli/speedtest-cli-0.2.5.ebuild
+++ b/net-analyzer/speedtest-cli/speedtest-cli-0.2.5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1998-2015 Gentoo Foundation
+# Copyright 1999-2015 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Header: /var/cvsroot/gentoo-x86/net-analyzer/speedtest-cli/speedtest-cli-0.2.5.ebuild,v 1.3 2015/01/24 14:12:18 ago Exp $
 

--- a/net-analyzer/speedtest-cli/speedtest-cli-0.2.5.ebuild
+++ b/net-analyzer/speedtest-cli/speedtest-cli-0.2.5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1998-2015 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Header: /var/cvsroot/gentoo-x86/net-analyzer/speedtest-cli/speedtest-cli-0.2.5.ebuild,v 1.3 2015/01/24 14:12:18 ago Exp $
 
@@ -16,6 +16,8 @@ LICENSE="Apache-2.0"
 SLOT="0"
 KEYWORDS="~amd64 ~ppc ~ppc64 ~x86"
 IUSE=""
+
+DEPEND="dev-python/setuptools[${PYTHON_USEDEP}]"
 
 DOCS=( CONTRIBUTING.md )
 


### PR DESCRIPTION
This annoyed me for quite some time. Especially on minimal systems, were setuptools wasn't pulled by any other packages, i've hit this quite often. Would be nice if we could finally add this dependency.

Gentoo-Bug: https://bugs.gentoo.org/show_bug.cgi?id=502302
Btw, the bug is for Version 0.2.4, but it's still valid for 0.2.5 - just testet it + see duplicate.

Maybe this should also block: https://bugs.gentoo.org/show_bug.cgi?id=530994
