### PR TITLE
sys-fs/cryptsetup - fix typo in dmcrypt.confd (bug #518592)

### DIFF
--- a/sys-fs/cryptsetup/files/1.0.6-dmcrypt.confd
+++ b/sys-fs/cryptsetup/files/1.0.6-dmcrypt.confd
@@ -93,6 +93,6 @@
 #post_mount='chown root:root ${mount_point}; chmod 1777 ${mount_point}'
 
 ## Loopback file example
-#mount='crypt-loop-home'
+#target='crypt-loop-home'
 #source='/dev/loop0'
 #loop_file='/mnt/crypt/home'


### PR DESCRIPTION
This is a very simple fix for a typo in the dmcrypt configuration file. "mount" should be replaced by "target" since mount isn't described anywhere in the configuration file and also doesn't work while the same example would work with "target". 

Gentoo Bug: https://bugs.gentoo.org/show_bug.cgi?id=518592
