### PR TITLE
media-video/rtmpdump - fix multilib build (bug #501098)

### DIFF
--- a/media-video/rtmpdump/rtmpdump-2.4_p20131018.ebuild
+++ b/media-video/rtmpdump/rtmpdump-2.4_p20131018.ebuild
@@ -17,9 +17,9 @@ KEYWORDS="amd64 ~arm hppa ~mips ppc ppc64 x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux
 IUSE="gnutls polarssl ssl"
 
 DEPEND="ssl? (
-		gnutls? ( net-libs/gnutls )
-		polarssl? ( !gnutls? ( >=net-libs/polarssl-0.14.0 ) )
-		!gnutls? ( !polarssl? ( dev-libs/openssl ) )
+		gnutls? ( net-libs/gnutls[${MULTILIB_USEDEP}] )
+		polarssl? ( !gnutls? ( >=net-libs/polarssl-0.14.0[${MULTILIB_USEDEP}] ) )
+		!gnutls? ( !polarssl? ( dev-libs/openssl[${MULTILIB_USEDEP}] ) )
 	)
 	sys-libs/zlib"
 RDEPEND="${DEPEND}"
@@ -60,7 +60,7 @@ multilib_src_compile() {
 	fi
 	#fix multilib-script support. Bug #327449
 	sed -i "/^libdir/s:lib$:$(get_libdir)$:" librtmp/Makefile
-	if ! multilib_build_binaries; then
+	if ! multilib_is_native_abi; then
 		cd librtmp
 	fi
 	emake CC="$(tc-getCC)" LD="$(tc-getLD)" \

--- a/media-video/rtmpdump/rtmpdump-2.4_p20131018.ebuild
+++ b/media-video/rtmpdump/rtmpdump-2.4_p20131018.ebuild
@@ -61,7 +61,7 @@ multilib_src_compile() {
 	#fix multilib-script support. Bug #327449
 	sed -i "/^libdir/s:lib$:$(get_libdir)$:" librtmp/Makefile
 	if ! multilib_is_native_abi; then
-		cd librtmp
+		cd librtmp || die
 	fi
 	emake CC="$(tc-getCC)" LD="$(tc-getLD)" \
 		OPT="${CFLAGS}" XLDFLAGS="${LDFLAGS}" CRYPTO="${crypto}" SYS=posix

--- a/media-video/rtmpdump/rtmpdump-2.4_p20131018.ebuild
+++ b/media-video/rtmpdump/rtmpdump-2.4_p20131018.ebuild
@@ -17,11 +17,11 @@ KEYWORDS="amd64 ~arm hppa ~mips ppc ppc64 x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux
 IUSE="gnutls polarssl ssl"
 
 DEPEND="ssl? (
-		gnutls? ( net-libs/gnutls[${MULTILIB_USEDEP}] )
-		polarssl? ( !gnutls? ( >=net-libs/polarssl-0.14.0[${MULTILIB_USEDEP}] ) )
-		!gnutls? ( !polarssl? ( dev-libs/openssl[${MULTILIB_USEDEP}] ) )
+		gnutls? ( >=net-libs/gnutls-2.12.23-r6[${MULTILIB_USEDEP}] )
+		polarssl? ( !gnutls? ( >=net-libs/polarssl-1.3.4[${MULTILIB_USEDEP}] ) )
+		!gnutls? ( !polarssl? ( >=dev-libs/openssl-1.0.1h-r2[${MULTILIB_USEDEP}] ) )
 	)
-	sys-libs/zlib[${MULTILIB_USEDEP}]"
+	>=sys-libs/zlib-1.2.8-r1[${MULTILIB_USEDEP}]"
 RDEPEND="${DEPEND}"
 
 pkg_setup() {

--- a/media-video/rtmpdump/rtmpdump-2.4_p20131018.ebuild
+++ b/media-video/rtmpdump/rtmpdump-2.4_p20131018.ebuild
@@ -21,7 +21,7 @@ DEPEND="ssl? (
 		polarssl? ( !gnutls? ( >=net-libs/polarssl-0.14.0[${MULTILIB_USEDEP}] ) )
 		!gnutls? ( !polarssl? ( dev-libs/openssl[${MULTILIB_USEDEP}] ) )
 	)
-	sys-libs/zlib"
+	sys-libs/zlib[${MULTILIB_USEDEP}]"
 RDEPEND="${DEPEND}"
 
 pkg_setup() {

--- a/media-video/rtmpdump/rtmpdump-2.4_p20131018.ebuild
+++ b/media-video/rtmpdump/rtmpdump-2.4_p20131018.ebuild
@@ -25,7 +25,7 @@ DEPEND="ssl? (
 RDEPEND="${DEPEND}"
 
 pkg_setup() {
-	if ! use ssl && ( use gnutls || use polarssl ) ; then
+	if ! use ssl && { use gnutls || use polarssl; }; then
 		ewarn "USE='gnutls polarssl' are ignored without USE='ssl'."
 		ewarn "Please review the local USE flags for this package."
 	fi
@@ -33,7 +33,7 @@ pkg_setup() {
 
 src_unpack() {
 	mkdir -p "${S}" || die "Can't create source directory"
-	cd "${S}"
+	cd "${S}" || die
 	unpack ${A}
 }
 
@@ -59,7 +59,7 @@ multilib_src_compile() {
 		fi
 	fi
 	#fix multilib-script support. Bug #327449
-	sed -i "/^libdir/s:lib$:$(get_libdir)$:" librtmp/Makefile
+	sed -i "/^libdir/s:lib$:$(get_libdir)$:" librtmp/Makefile || die
 	if ! multilib_is_native_abi; then
 		cd librtmp || die
 	fi
@@ -68,11 +68,11 @@ multilib_src_compile() {
 }
 
 multilib_src_install() {
-	mkdir -p "${ED}"/${DESTTREE}/$(get_libdir)
+	mkdir -p "${ED}"/${DESTTREE}/$(get_libdir) || die
 	if multilib_is_native_abi; then
 		dodoc README ChangeLog rtmpdump.1.html rtmpgw.8.html
 	else
-		cd librtmp
+		cd librtmp || die
 	fi
 	emake DESTDIR="${ED}" prefix="${DESTTREE}" mandir="${DESTTREE}/share/man" \
 	CRYPTO="${crypto}" install

--- a/media-video/rtmpdump/rtmpdump-2.4_p20131018.ebuild
+++ b/media-video/rtmpdump/rtmpdump-2.4_p20131018.ebuild
@@ -20,8 +20,8 @@ DEPEND="ssl? (
 		gnutls? ( >=net-libs/gnutls-2.12.23-r6[${MULTILIB_USEDEP}] )
 		polarssl? ( !gnutls? ( >=net-libs/polarssl-1.3.4[${MULTILIB_USEDEP}] ) )
 		!gnutls? ( !polarssl? ( >=dev-libs/openssl-1.0.1h-r2[${MULTILIB_USEDEP}] ) )
-	)
-	>=sys-libs/zlib-1.2.8-r1[${MULTILIB_USEDEP}]"
+		>=sys-libs/zlib-1.2.8-r1[${MULTILIB_USEDEP}]
+	)"
 RDEPEND="${DEPEND}"
 
 pkg_setup() {

--- a/media-video/rtmpdump/rtmpdump-9999.ebuild
+++ b/media-video/rtmpdump/rtmpdump-9999.ebuild
@@ -54,7 +54,7 @@ multilib_src_compile() {
 	fi
 	#fix multilib-script support. Bug #327449
 	sed -i "/^libdir/s:lib$:$(get_libdir)$:" librtmp/Makefile
-	if ! multilib_build_binaries; then
+	if ! multilib_is_native_abi; then
 		cd librtmp
 	fi
 	emake CC="$(tc-getCC)" LD="$(tc-getLD)" \

--- a/media-video/rtmpdump/rtmpdump-9999.ebuild
+++ b/media-video/rtmpdump/rtmpdump-9999.ebuild
@@ -55,7 +55,7 @@ multilib_src_compile() {
 	#fix multilib-script support. Bug #327449
 	sed -i "/^libdir/s:lib$:$(get_libdir)$:" librtmp/Makefile
 	if ! multilib_is_native_abi; then
-		cd librtmp
+		cd librtmp || die
 	fi
 	emake CC="$(tc-getCC)" LD="$(tc-getLD)" \
 		OPT="${CFLAGS}" XLDFLAGS="${LDFLAGS}" CRYPTO="${crypto}" SYS=posix

--- a/media-video/rtmpdump/rtmpdump-9999.ebuild
+++ b/media-video/rtmpdump/rtmpdump-9999.ebuild
@@ -25,7 +25,7 @@ DEPEND="ssl? (
 RDEPEND="${DEPEND}"
 
 pkg_setup() {
-	if ! use ssl && ( use gnutls || use polarssl ) ; then
+	if ! use ssl && { use gnutls || use polarssl; }; then
 		ewarn "USE='gnutls polarssl' are ignored without USE='ssl'."
 		ewarn "Please review the local USE flags for this package."
 	fi
@@ -53,7 +53,7 @@ multilib_src_compile() {
 		fi
 	fi
 	#fix multilib-script support. Bug #327449
-	sed -i "/^libdir/s:lib$:$(get_libdir)$:" librtmp/Makefile
+	sed -i "/^libdir/s:lib$:$(get_libdir)$:" librtmp/Makefile || die
 	if ! multilib_is_native_abi; then
 		cd librtmp || die
 	fi
@@ -62,11 +62,11 @@ multilib_src_compile() {
 }
 
 multilib_src_install() {
-	mkdir -p "${ED}"/${DESTTREE}/$(get_libdir)
+	mkdir -p "${ED}"/${DESTTREE}/$(get_libdir) || die
 	if multilib_is_native_abi; then
 		dodoc README ChangeLog rtmpdump.1.html rtmpgw.8.html
 	else
-		cd librtmp
+		cd librtmp || die
 	fi
 	emake DESTDIR="${ED}" prefix="${DESTTREE}" mandir="${DESTTREE}/share/man" \
 		CRYPTO="${crypto}" install

--- a/media-video/rtmpdump/rtmpdump-9999.ebuild
+++ b/media-video/rtmpdump/rtmpdump-9999.ebuild
@@ -20,8 +20,8 @@ DEPEND="ssl? (
 		gnutls? ( >=net-libs/gnutls-2.12.23-r6[${MULTILIB_USEDEP}] )
 		polarssl? ( !gnutls? ( >=net-libs/polarssl-1.3.4[${MULTILIB_USEDEP}] ) )
 		!gnutls? ( !polarssl? ( >=dev-libs/openssl-1.0.1h-r2[${MULTILIB_USEDEP}] ) )
-	)
-	>=sys-libs/zlib-1.2.8-r1[${MULTILIB_USEDEP}]"
+		>=sys-libs/zlib-1.2.8-r1[${MULTILIB_USEDEP}]
+	)"
 RDEPEND="${DEPEND}"
 
 pkg_setup() {


### PR DESCRIPTION
This fixes multilib build for rtmpdump.
The actual stable version in tree is broken so i've just added the missing parts (note: the live version already includes multilib dependencies). I've also changed multilib_build_binaries with multilib_is_native_abi since the first one is deprecated.

Regarding zlib: Is it really needed to have multilib dependencies here as well? multilib rtmpdump seems to build fine even without multilib zlib.

I've test-build rtmpdump without any flags, ssl and ssl+gnutls enabled. However i didn't test building it with polarssl support.

Gentoo Bug: https://bugs.gentoo.org/show_bug.cgi?id=501098
