### PR TITLE
games-fps/quake3-osp - fix download link, add missing die (bug #460312)

### DIFF
--- a/games-fps/quake3-osp/quake3-osp-1.03a-r1.ebuild
+++ b/games-fps/quake3-osp/quake3-osp-1.03a-r1.ebuild
@@ -11,14 +11,14 @@ MOD_DIR="osp"
 inherit games games-mods
 
 HOMEPAGE="http://www.orangesmoothie.org/"
-SRC_URI="http://www.sunflow.com/orangesmoothie/downloads/osp-Quake3-${PV}_full.zip"
+SRC_URI="http://osp.dget.cc/orangesmoothie/downloads/osp-Quake3-${PV}_full.zip"
 
 LICENSE="GPL-2"
 KEYWORDS="amd64 ~ppc x86"
 IUSE="dedicated opengl"
 
 src_prepare() {
-	cd ${MOD_DIR}
-	rm -f VoodooStats-ReadMe.txt *.exe
-	rm -rf voodoo
+	cd ${MOD_DIR} || die
+	rm -f VoodooStats-ReadMe.txt *.exe || die
+	rm -rf voodoo || die
 }


### PR DESCRIPTION
This is a simple fix for gentoo bug 460312[1]. However, i don't know if it's worth fixing since there are clearly other problems with this ebuild (among other "game-mod" ebuilds).
First of all, i couldn't raise the EAPI Version (it's still EAPI=2) because "ebuild ... manifest" would complain about:

> Error(s) in metadata for 'games-fps/quake3-osp-1.03a-r1':
>  RDEPEND: expected: dependency string, got: ')', token 5

I guess this comes from the games-mods eclass? At least i couldn't find a way to fix this.
Secoundly "repoman full" also complains:

> RepoMan scours the neighborhood...
>  dependency.unknown            1
>   games-fps/quake3-osp/quake3-osp-1.03a-r1.ebuild: RDEPEND: games-fps/quake3-bin[opengl]
>  ebuild.notadded               1
>   games-fps/quake3-osp/quake3-osp-1.03a-r1.ebuild

Again - no idea how to fix this (apart from maybe spending hours on eclasse's ;) ), but since other game mod ebuilds have the same issue i didn't look further here. I guess those game-mods and/or the eclass would need an overall update..

After all i've added missing die's for the rm/cd commands :)
Sources are linked on the official HP and can be found here: [2] 

[1]https://bugs.gentoo.org/show_bug.cgi?id=460312
[2]http://www.orangesmoothie.org/download.html
