### PR TITLE
Fix typos/grammar in README.gentoo

### DIFF
--- a/dev-java/icedtea-web/files/README.gentoo
+++ b/dev-java/icedtea-web/files/README.gentoo
@@ -7,15 +7,15 @@ Select JVM
 ----------
 IcedTea-Web (>=1.4) supports selecting the JVM to use for the plugin. Currently
 works for all IcedTea releases. The eselect module java-nsplugin in
->=eselet-java-0.1.0 added support for this.
+>=eselect-java-0.1.0 added support for this.
 
 Per user configuration
 ----------------------
-IcedTea-Web also supports per user configuration which take precedence over the
+IcedTea-Web also supports per user configuration which takes precedence over the
 global choice of JVM managed by the java-nsplugin module. If you made use of
 itweb-settings as user to set a JVM for instance and want to give control back
 to java-nsplugin to manage the JVM to use run as your user:
 'sed -i -e "/^deployment.jre.dir=/d" ~/.icedtea/deployment.properties'
 
-Per user plugin selection via eselct java-nsplugin is a longstanding feature
+Per user plugin selection via eselect java-nsplugin is a longstanding feature
 request. Bug 148632


### PR DESCRIPTION
`eselet` → `eselect`
`eselct` → `eselect`
`take` → `takes`
