### PR TITLE
boot0,freebsd-{lib,libexec}: fix bug 511698, it's a critical bug.

### DIFF
--- a/sys-freebsd/boot0/boot0-9.1.ebuild
+++ b/sys-freebsd/boot0/boot0-9.1.ebuild
@@ -22,7 +22,8 @@ DEPEND="=sys-freebsd/freebsd-mk-defs-${RV}*
 
 S="${WORKDIR}/sys/boot"
 
-PATCHES=( "${FILESDIR}/${PN}-9.2-gcc46.patch" )
+PATCHES=( "${FILESDIR}/${PN}-9.2-gcc46.patch"
+	"${FILESDIR}/${PN}-add-nossp-cflags.patch" )
 
 boot0_use_enable() {
 	use ${1} && mymakeopts="${mymakeopts} LOADER_${2}_SUPPORT=\"yes\""

--- a/sys-freebsd/boot0/boot0-9.2.ebuild
+++ b/sys-freebsd/boot0/boot0-9.2.ebuild
@@ -24,7 +24,8 @@ DEPEND="=sys-freebsd/freebsd-mk-defs-${RV}*
 
 S="${WORKDIR}/sys/boot"
 
-PATCHES=( "${FILESDIR}/${PN}-9.2-gcc46.patch" )
+PATCHES=( "${FILESDIR}/${PN}-9.2-gcc46.patch"
+	"${FILESDIR}/${PN}-add-nossp-cflags.patch" )
 
 boot0_use_enable() {
 	use ${1} && mymakeopts="${mymakeopts} LOADER_${2}_SUPPORT=\"yes\""

--- a/sys-freebsd/boot0/files/boot0-add-nossp-cflags.patch
+++ b/sys-freebsd/boot0/files/boot0-add-nossp-cflags.patch
@@ -1,0 +1,11 @@
+https://bugs.gentoo.org/show_bug.cgi?id=511698
+
+diff --git a/sys/boot/Makefile.inc b/sys/boot/Makefile.inc
+index e0039b9..533dea0 100644
+--- a/sys/boot/Makefile.inc
++++ b/sys/boot/Makefile.inc
+@@ -1,3 +1,3 @@
+ # $FreeBSD: release/10.0.0/sys/boot/Makefile.inc 188895 2009-02-21 15:04:31Z ru $
+ 
+-SSP_CFLAGS=
++SSP_CFLAGS= -fno-stack-protector

--- a/sys-freebsd/freebsd-lib/files/freebsd-lib-add-nossp-cflags.patch
+++ b/sys-freebsd/freebsd-lib/files/freebsd-lib-add-nossp-cflags.patch
@@ -1,0 +1,30 @@
+Please do not disable this patch.
+All commands will be non-executable.
+Abort trap: 6 (core dumped) is displayed...
+
+Details see Gentoo Bug #511698.
+https://bugs.gentoo.org/show_bug.cgi?id=511698
+
+diff --git a/lib/libc/Makefile b/lib/libc/Makefile
+index 1cc23b7..7dd458e 100644
+--- a/lib/libc/Makefile
++++ b/lib/libc/Makefile
+@@ -149,6 +149,6 @@ CWARNFLAGS:=	${.IMPSRC:Ngdtoa_*.c:C/^.+$/${CWARNFLAGS}/:C/^$/-w/}
+ # in the future to circumvent this.
+ SSP_CFLAGS:=	${SSP_CFLAGS:S/^-fstack-protector-all$/-fstack-protector/}
+ # Disable stack protection for SSP symbols.
+-SSP_CFLAGS:=	${.IMPSRC:N*/stack_protector.c:C/^.+$/${SSP_CFLAGS}/}
++SSP_CFLAGS:=	${.IMPSRC:N*/stack_protector.c:C/^.+$/${SSP_CFLAGS}/:C/^$/-fno-stack-protector/}
+ # Generate stack unwinding tables for cancellation points
+ CANCELPOINTS_CFLAGS:=	${.IMPSRC:Mcancelpoints_*:C/^.+$/${CANCELPOINTS_CFLAGS}/:C/^$//}
+diff --git a/lib/csu/Makefile.inc b/lib/csu/Makefile.inc
+index f92d87d..7a3a2f3 100644
+--- a/lib/csu/Makefile.inc
++++ b/lib/csu/Makefile.inc
+@@ -1,5 +1,5 @@
+ # $FreeBSD: release/9.1.0/lib/csu/Makefile.inc 204757 2010-03-05 13:29:05Z uqs $
+ 
+-SSP_CFLAGS=
++SSP_CFLAGS= -fno-stack-protector
+
+ .include "../Makefile.inc"

--- a/sys-freebsd/freebsd-lib/freebsd-lib-9.1-r11.ebuild
+++ b/sys-freebsd/freebsd-lib/freebsd-lib-9.1-r11.ebuild
@@ -96,6 +96,7 @@ PATCHES=(
 	"${FILESDIR}/${PN}-9.0-cve-2010-2632.patch"
 	"${FILESDIR}/${PN}-9.0-bluetooth.patch"
 	"${FILESDIR}/${PN}-9.1-.eh_frame_hdr-fix.patch"
+	"${FILESDIR}/${PN}-add-nossp-cflags.patch"
 	)
 
 # Here we disable and remove source which we don't need or want

--- a/sys-freebsd/freebsd-lib/freebsd-lib-9.2.ebuild
+++ b/sys-freebsd/freebsd-lib/freebsd-lib-9.2.ebuild
@@ -94,6 +94,7 @@ PATCHES=(
 	"${FILESDIR}/${PN}-9.0-netware.patch"
 	"${FILESDIR}/${PN}-9.0-bluetooth.patch"
 	"${FILESDIR}/${PN}-9.1-.eh_frame_hdr-fix.patch"
+	"${FILESDIR}/${PN}-add-nossp-cflags.patch"
 	)
 
 # Here we disable and remove source which we don't need or want

--- a/sys-freebsd/freebsd-mk-defs/files/freebsd-mk-defs-add-nossp-cflags.patch
+++ b/sys-freebsd/freebsd-mk-defs/files/freebsd-mk-defs-add-nossp-cflags.patch
@@ -1,0 +1,28 @@
+https://bugs.gentoo.org/show_bug.cgi?id=511698
+
+diff --git a/share/mk/bsd.sys.mk b/share/mk/bsd.sys.mk
+index e438633..de4a05b 100644
+--- a/share/mk/bsd.sys.mk
++++ b/share/mk/bsd.sys.mk
+@@ -111,12 +111,18 @@ CLANG_OPT_SMALL= -mstack-alignment=8 -mllvm -inline-threshold=3\
+ CFLAGS+=	 -Qunused-arguments
+ .endif # CLANG
+ 
+-.if ${MK_SSP} != "no" && ${MACHINE_CPUARCH} != "ia64" && \
+-    ${MACHINE_CPUARCH} != "arm" && ${MACHINE_CPUARCH} != "mips"
++.if ${MACHINE_CPUARCH} != "ia64" && ${MACHINE_CPUARCH} != "arm" \
++    && ${MACHINE_CPUARCH} != "mips"
++.if ${MK_SSP} != "no"
+ # Don't use -Wstack-protector as it breaks world with -Werror.
+ SSP_CFLAGS?=	-fstack-protector
++.else
++# gcc-4.9, -fstack-protector-strong is enabled by default.
++# Add -fno-stack-protector to disable it. Gentoo Bug #511698.
++SSP_CFLAGS=	-fno-stack-protector
++.endif #SSP
+ CFLAGS+=	${SSP_CFLAGS}
+-.endif # SSP && !IA64 && !ARM && !MIPS
++.endif # !IA64 && !ARM && !MIPS
+ 
+ # Allow user-specified additional warning flags
+ CFLAGS+=	${CWARNFLAGS}

--- a/sys-freebsd/freebsd-mk-defs/freebsd-mk-defs-9.1.ebuild
+++ b/sys-freebsd/freebsd-mk-defs/freebsd-mk-defs-9.1.ebuild
@@ -23,6 +23,7 @@ S="${WORKDIR}/share/mk"
 
 src_prepare() {
 	epatch "${FILESDIR}/${PN}-9.1-gentoo.patch"
+	epatch "${FILESDIR}/${PN}-add-nossp-cflags.patch"
 	use userland_GNU && epatch "${FILESDIR}/${PN}-9.1-gnu.patch"
 }
 

--- a/sys-freebsd/freebsd-mk-defs/freebsd-mk-defs-9.2.ebuild
+++ b/sys-freebsd/freebsd-mk-defs/freebsd-mk-defs-9.2.ebuild
@@ -25,6 +25,7 @@ S="${WORKDIR}/share/mk"
 
 src_prepare() {
 	epatch "${FILESDIR}/${PN}-9.2-gentoo.patch"
+	epatch "${FILESDIR}/${PN}-add-nossp-cflags.patch"
 	use userland_GNU && epatch "${FILESDIR}/${PN}-9.2-gnu.patch"
 }
 


### PR DESCRIPTION
Hello.
This is a request to fix the critical issue that reported in May last year.
If patch set is not applied, it is possible that all of the command is unexecutable.

boot0,sys-freebsd/freebsd-{lib,libexec}: compile with gcc-4.8.3 or later, ALL COMMANDS RETURNS Abort trap: 6 (core dumped)
https://bugs.gentoo.org/show_bug.cgi?id=511698
