### PR TITLE
#FL-2108 && upstream #89213: make pulseaudio's udev use require alsa or oss use

### DIFF
--- a/media-sound/pulseaudio/pulseaudio-5.0-r4.ebuild
+++ b/media-sound/pulseaudio/pulseaudio-5.0-r4.ebuild
@@ -23,7 +23,8 @@ gtk ipv6 jack libsamplerate lirc neon +orc oss qt4 realtime ssl systemd
 system-wide tcpd test +udev +webrtc-aec +X xen"
 
 # See "*** BLUEZ support not found (requires D-Bus)" in configure.ac
-REQUIRED_USE="bluetooth? ( dbus )"
+REQUIRED_USE="bluetooth? ( dbus )
+	udev? ( || ( alsa oss ) )"
 
 # libpcre needed in some cases, bug #472228
 RDEPEND="

--- a/media-sound/pulseaudio/pulseaudio-5.0-r5.ebuild
+++ b/media-sound/pulseaudio/pulseaudio-5.0-r5.ebuild
@@ -23,7 +23,8 @@ gtk ipv6 jack libsamplerate lirc neon +orc oss qt4 realtime ssl systemd
 system-wide tcpd test +udev +webrtc-aec +X xen zeroconf"
 
 # See "*** BLUEZ support not found (requires D-Bus)" in configure.ac
-REQUIRED_USE="bluetooth? ( dbus )"
+REQUIRED_USE="bluetooth? ( dbus )
+	udev? ( || ( alsa oss ) )"
 
 # libpcre needed in some cases, bug #472228
 RDEPEND="

--- a/media-sound/pulseaudio/pulseaudio-5.0-r6.ebuild
+++ b/media-sound/pulseaudio/pulseaudio-5.0-r6.ebuild
@@ -24,7 +24,8 @@ gnome gtk ipv6 jack libsamplerate lirc neon +orc oss qt4 realtime ssl systemd
 system-wide tcpd test +udev +webrtc-aec +X xen zeroconf"
 
 # See "*** BLUEZ support not found (requires D-Bus)" in configure.ac
-REQUIRED_USE="bluetooth? ( dbus )"
+REQUIRED_USE="bluetooth? ( dbus )
+	udev? ( || ( alsa oss ) )"
 
 # libpcre needed in some cases, bug #472228
 RDEPEND="

--- a/media-sound/pulseaudio/pulseaudio-5.0-r7.ebuild
+++ b/media-sound/pulseaudio/pulseaudio-5.0-r7.ebuild
@@ -24,7 +24,8 @@ gnome gtk ipv6 jack libsamplerate lirc neon +orc oss qt4 realtime ssl systemd
 system-wide tcpd test +udev +webrtc-aec +X xen zeroconf"
 
 # See "*** BLUEZ support not found (requires D-Bus)" in configure.ac
-REQUIRED_USE="bluetooth? ( dbus )"
+REQUIRED_USE="bluetooth? ( dbus )
+	udev? ( || ( alsa oss ) )"
 
 # libpcre needed in some cases, bug #472228
 RDEPEND="

--- a/media-sound/pulseaudio/pulseaudio-5.99.3.ebuild
+++ b/media-sound/pulseaudio/pulseaudio-5.99.3.ebuild
@@ -28,7 +28,8 @@ IUSE="+alsa +alsa-plugin +asyncns bluetooth +caps dbus doc equalizer +gdbm +glib
 # See "*** BLUEZ support not found (requires D-Bus)" in configure.ac
 REQUIRED_USE="bluetooth? ( dbus )
 		ofono-headset? ( bluetooth )
-		native-headset? ( bluetooth )"
+		native-headset? ( bluetooth )
+		udev? ( || ( alsa oss ) )"
 
 # libpcre needed in some cases, bug #472228
 RDEPEND="


### PR DESCRIPTION
making pulseaudio's udev use depend on/require alsa or oss use as it is described/declared at the sources.

credits for resolving this bug goes to @mgorny and Nexie Kind from funtoo-users.
