### PR TITLE
sys-process/pidof-bsd-20050501-r4: fix compile fails on FreeBSD 10.0

### DIFF
--- a/sys-process/pidof-bsd/files/pidof-bsd-20050501-fbsd10.patch
+++ b/sys-process/pidof-bsd/files/pidof-bsd-20050501-fbsd10.patch
@@ -1,3 +1,8 @@
+share/mk/bsd.compat.mk has been removed from FreeBSD 10.0.
+An old style NOMAN is not supported anymore.
+
+https://bugs.gentoo.org/show_bug.cgi?id=483044
+
 diff --git a/Makefile b/Makefile
 index d2d760b..446bd6f 100644
 --- a/Makefile

--- a/sys-process/pidof-bsd/files/pidof-bsd-20050501-fbsd10.patch
+++ b/sys-process/pidof-bsd/files/pidof-bsd-20050501-fbsd10.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile b/Makefile
+index d2d760b..446bd6f 100644
+--- a/Makefile
++++ b/Makefile
+@@ -2,7 +2,7 @@
+ 
+ PROG=	pidof
+ SRCS=	pidof.c
+-NOMAN=	yes
++NO_MAN=	yes
+ LDADD=	-lkvm
+ LINKS=	${BINDIR}/pidof
+ 

--- a/sys-process/pidof-bsd/pidof-bsd-20050501-r4.ebuild
+++ b/sys-process/pidof-bsd/pidof-bsd-20050501-r4.ebuild
@@ -20,7 +20,8 @@ S="${WORKDIR}/pidof"
 
 PATCHES=( "${FILESDIR}/${P}-gfbsd.patch"
 	"${FILESDIR}/${P}-firstarg.patch"
-	"${FILESDIR}/${P}-pname.patch" )
+	"${FILESDIR}/${P}-pname.patch"
+	"${FILESDIR}/${P}-fbsd10.patch" )
 
 src_install() {
 	into /


### PR DESCRIPTION
NOMAN is not longer supported. Need to change to NO_MAN.

https://bugs.gentoo.org/show_bug.cgi?id=483044

NOTE,
NO_MAN is already supported on FreeBSD 8.0.
