### PR TITLE
freebsd.eclass: Fix for FreeBSD10.0 or later

### DIFF
--- a/eclass/freebsd.eclass
+++ b/eclass/freebsd.eclass
@@ -129,6 +129,12 @@ freebsd_rename_libraries() {
 freebsd_src_unpack() {
 	if [[ ${MY_PV} == *9999* ]]; then
 		S="${WORKDIR}" subversion_src_unpack
+
+		# When share/mk exists in ${WORKDIR}, it is used on FreeBSD 10.0
+		# Removed "${WORKDIR}"/share/mk/*.mk, use to force /usr/share/mk.
+		if [[ ${PN} != freebsd-mk-defs ]] ; then
+			[[ -e "${WORKDIR}"/share/mk ]] && rm -rf "${WORKDIR}"/share/mk/*.mk
+		fi
 	else
 		unpack ${A}
 	fi
@@ -141,7 +147,8 @@ freebsd_src_unpack() {
 
 	# Starting from FreeBSD 9.2, its install command supports the -l option and
 	# they now use it. Emulate it if we are on a system that does not have it.
-	if [[ ${RV} > 9.1 ]] && ! has_version '>=sys-freebsd/freebsd-ubin-9.2_beta1' ; then
+	version_compare ${RV} 9.1
+	if [[ $? -eq 3 ]] && ! has_version '>=sys-freebsd/freebsd-ubin-9.2_beta1' ; then
 		export INSTALL_LINK="ln -f"
 		export INSTALL_SYMLINK="ln -fs"
 	fi

--- a/eclass/freebsd.eclass
+++ b/eclass/freebsd.eclass
@@ -147,8 +147,7 @@ freebsd_src_unpack() {
 
 	# Starting from FreeBSD 9.2, its install command supports the -l option and
 	# they now use it. Emulate it if we are on a system that does not have it.
-	version_compare ${RV} 9.1
-	if [[ $? -eq 3 ]] && ! has_version '>=sys-freebsd/freebsd-ubin-9.2_beta1' ; then
+	if version_is_at_least 9.2 ${RV} && ! has_version '>=sys-freebsd/freebsd-ubin-9.2_beta1' ; then
 		export INSTALL_LINK="ln -f"
 		export INSTALL_SYMLINK="ln -fs"
 	fi


### PR DESCRIPTION
-9999 ebuild, changed to use to force /usr/share/mk.
Fixed a problem of numerical comparison in 10.0.

Details please see
https://bugs.gentoo.org/show_bug.cgi?id=488214#c23
https://bugs.gentoo.org/show_bug.cgi?id=488214#c24
