### PR TITLE
sys-devel/binutils-2.25: added ~amd64-fbsd keywords, bug 499212.

### DIFF
--- a/sys-devel/binutils/binutils-2.25.ebuild
+++ b/sys-devel/binutils/binutils-2.25.ebuild
@@ -8,4 +8,4 @@ PATCHVER="1.0"
 ELF2FLT_VER=""
 inherit toolchain-binutils
 
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 -amd64-fbsd -sparc-fbsd ~x86-fbsd"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd -sparc-fbsd ~x86-fbsd"


### PR DESCRIPTION
This PR is KEYWORDREQ.

https://bugs.gentoo.org/show_bug.cgi?id=499212
