### PR TITLE
sys-apps/coreutils-8.23: added ~x86-fbsd keywords, bug 507536.

### DIFF
--- a/sys-apps/coreutils/coreutils-8.23.ebuild
+++ b/sys-apps/coreutils/coreutils-8.23.ebuild
@@ -23,7 +23,7 @@ SRC_URI="mirror://gnu/${PN}/${P}.tar.xz
 
 LICENSE="GPL-3"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~arm-linux ~x86-linux"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~arm-linux ~x86-linux"
 IUSE="acl caps gmp multicall nls selinux static userland_BSD vanilla xattr"
 
 LIB_DEPEND="acl? ( sys-apps/acl[static-libs] )


### PR DESCRIPTION
This PR is KEYWORDREQ.
https://bugs.gentoo.org/show_bug.cgi?id=507536

NOTE,
coreutils is required for packages that require the GNU tools.

e.g.) =x11-proto/xextproto-7.2.99.901: install fails on Gentoo/FreeBSD
https://bugs.gentoo.org/show_bug.cgi?id=492874
