### PR TITLE
added deprecated to fbsd/{9.1,9.2} profiles.

### DIFF
--- a/profiles/default/bsd/fbsd/amd64/9.1/clang/deprecated
+++ b/profiles/default/bsd/fbsd/amd64/9.1/clang/deprecated
@@ -2,4 +2,3 @@ default/bsd/fbsd/amd64/clang/10.1
 Please read carefully the wiki.
 Might be your environment is broken if you do not perform the correct procedure.
 https://wiki.gentoo.org/wiki/Gentoo_FreeBSD#Upgrade_howto
-

--- a/profiles/default/bsd/fbsd/amd64/9.1/clang/deprecated
+++ b/profiles/default/bsd/fbsd/amd64/9.1/clang/deprecated
@@ -1,0 +1,5 @@
+default/bsd/fbsd/amd64/clang/10.1
+Please read carefully the wiki.
+Might be your environment is broken if you do not perform the correct procedure.
+https://wiki.gentoo.org/wiki/Gentoo_FreeBSD#Upgrade_howto
+

--- a/profiles/default/bsd/fbsd/amd64/9.1/deprecated
+++ b/profiles/default/bsd/fbsd/amd64/9.1/deprecated
@@ -1,0 +1,5 @@
+default/bsd/fbsd/amd64/10.1
+Please read carefully the wiki.
+Might be your environment is broken if you do not perform the correct procedure.
+https://wiki.gentoo.org/wiki/Gentoo_FreeBSD#Upgrade_howto
+

--- a/profiles/default/bsd/fbsd/amd64/9.1/deprecated
+++ b/profiles/default/bsd/fbsd/amd64/9.1/deprecated
@@ -2,4 +2,3 @@ default/bsd/fbsd/amd64/10.1
 Please read carefully the wiki.
 Might be your environment is broken if you do not perform the correct procedure.
 https://wiki.gentoo.org/wiki/Gentoo_FreeBSD#Upgrade_howto
-

--- a/profiles/default/bsd/fbsd/amd64/9.2/clang/deprecated
+++ b/profiles/default/bsd/fbsd/amd64/9.2/clang/deprecated
@@ -2,4 +2,3 @@ default/bsd/fbsd/amd64/clang/10.1
 Please read carefully the wiki.
 Might be your environment is broken if you do not perform the correct procedure.
 https://wiki.gentoo.org/wiki/Gentoo_FreeBSD#Upgrade_howto
-

--- a/profiles/default/bsd/fbsd/amd64/9.2/clang/deprecated
+++ b/profiles/default/bsd/fbsd/amd64/9.2/clang/deprecated
@@ -1,0 +1,5 @@
+default/bsd/fbsd/amd64/clang/10.1
+Please read carefully the wiki.
+Might be your environment is broken if you do not perform the correct procedure.
+https://wiki.gentoo.org/wiki/Gentoo_FreeBSD#Upgrade_howto
+

--- a/profiles/default/bsd/fbsd/amd64/9.2/deprecated
+++ b/profiles/default/bsd/fbsd/amd64/9.2/deprecated
@@ -1,0 +1,5 @@
+default/bsd/fbsd/amd64/10.1
+Please read carefully the wiki.
+Might be your environment is broken if you do not perform the correct procedure.
+https://wiki.gentoo.org/wiki/Gentoo_FreeBSD#Upgrade_howto
+

--- a/profiles/default/bsd/fbsd/amd64/9.2/deprecated
+++ b/profiles/default/bsd/fbsd/amd64/9.2/deprecated
@@ -2,4 +2,3 @@ default/bsd/fbsd/amd64/10.1
 Please read carefully the wiki.
 Might be your environment is broken if you do not perform the correct procedure.
 https://wiki.gentoo.org/wiki/Gentoo_FreeBSD#Upgrade_howto
-

--- a/profiles/default/bsd/fbsd/x86/9.1/deprecated
+++ b/profiles/default/bsd/fbsd/x86/9.1/deprecated
@@ -2,4 +2,3 @@ default/bsd/fbsd/x86/10.1
 Please read carefully the wiki.
 Might be your environment is broken if you do not perform the correct procedure.
 https://wiki.gentoo.org/wiki/Gentoo_FreeBSD#Upgrade_howto
-

--- a/profiles/default/bsd/fbsd/x86/9.1/deprecated
+++ b/profiles/default/bsd/fbsd/x86/9.1/deprecated
@@ -1,0 +1,5 @@
+default/bsd/fbsd/x86/10.1
+Please read carefully the wiki.
+Might be your environment is broken if you do not perform the correct procedure.
+https://wiki.gentoo.org/wiki/Gentoo_FreeBSD#Upgrade_howto
+

--- a/profiles/default/bsd/fbsd/x86/9.2/deprecated
+++ b/profiles/default/bsd/fbsd/x86/9.2/deprecated
@@ -2,4 +2,3 @@ default/bsd/fbsd/x86/10.1
 Please read carefully the wiki.
 Might be your environment is broken if you do not perform the correct procedure.
 https://wiki.gentoo.org/wiki/Gentoo_FreeBSD#Upgrade_howto
-

--- a/profiles/default/bsd/fbsd/x86/9.2/deprecated
+++ b/profiles/default/bsd/fbsd/x86/9.2/deprecated
@@ -1,0 +1,5 @@
+default/bsd/fbsd/x86/10.1
+Please read carefully the wiki.
+Might be your environment is broken if you do not perform the correct procedure.
+https://wiki.gentoo.org/wiki/Gentoo_FreeBSD#Upgrade_howto
+


### PR DESCRIPTION
I'll add deprecated to the fbsd's old profile.

```
# emerge --info

!!! Your current profile is deprecated and not supported anymore.
!!! Use eselect profile to update your profile.
!!! Please upgrade to the following profile if possible:

        default/bsd/fbsd/x86/10.1

To upgrade do the following steps:
Please read carefully the wiki.
Might be your environment is broken if you do not perform the correct procedure.
https://wiki.gentoo.org/wiki/Gentoo_FreeBSD#Upgrade_howto

```
