### PR TITLE
isl: improve Gentoo Prefix compatibility

### DIFF
--- a/dev-libs/isl/files/isl-0.07-gdb-autoload-dir.patch
+++ b/dev-libs/isl/files/isl-0.07-gdb-autoload-dir.patch
@@ -9,9 +9,9 @@ Install python module into gdb auto-load directory.
 -		$(DESTDIR)$(libdir)/$$libisl-gdb.py; \
 -	test -z "$(libdir)" || $(MKDIR_P) "$(DESTDIR)$(libdir)"; \
 -	$(INSTALL_DATA) $(srcdir)/isl.py $(DESTDIR)$(libdir)/$$libisl-gdb.py; esac
-+		$(DESTDIR)usr/share/gdb/auto-load$(libdir)/$$libisl-gdb.py; \
-+	test -z "$(libdir)" || $(MKDIR_P) "$(DESTDIR)usr/share/gdb/auto-load$(libdir)"; \
-+	$(INSTALL_DATA) $(srcdir)/isl.py $(DESTDIR)usr/share/gdb/auto-load$(libdir)/$$libisl-gdb.py; esac
++		$(DESTDIR)$(prefix)/share/gdb/auto-load$(libdir)/$$libisl-gdb.py; \
++	test -z "$(libdir)" || $(MKDIR_P) "$(DESTDIR)$(prefix)/share/gdb/auto-load$(libdir)"; \
++	$(INSTALL_DATA) $(srcdir)/isl.py $(DESTDIR)$(prefix)/share/gdb/auto-load$(libdir)/$$libisl-gdb.py; esac
  
  # Tell versions [3.59,3.63) of GNU make to not export all variables.
  # Otherwise a system limit (for SysV at least) may be exceeded.


### PR DESCRIPTION
The current autoload-dir patch installs the python files into `/usr/share/`...
For Gentoo Prefix it should be rather `$(EPREFIX)/usr/share`...
The proper way for both normal and prefix installs would be to use `$(prefix)`.
