### PR TITLE
Bug #547270 Add gtk3 useflag -- for Xfce 4.12 instead of only libxfce4ui

### DIFF
--- a/xfce-base/garcon/garcon-0.4.0.ebuild
+++ b/xfce-base/garcon/garcon-0.4.0.ebuild
@@ -16,9 +16,7 @@ IUSE="debug"
 
 RDEPEND=">=dev-libs/glib-2.30:=
 	>=x11-libs/gtk+-2.24:2=
-	>=x11-libs/gtk+-3.14:3=
-	>=xfce-base/libxfce4ui-4.11.1:=[gtk3(+)]
-	>=xfce-base/libxfce4util-4.11:="
+	>=xfce-base/libxfce4ui-4.10:="
 DEPEND="${RDEPEND}
 	dev-util/intltool
 	sys-devel/gettext

--- a/xfce-base/libxfce4ui/libxfce4ui-4.12.1-r1.ebuild
+++ b/xfce-base/libxfce4ui/libxfce4ui-4.12.1-r1.ebuild
@@ -1,0 +1,47 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Header: /var/cvsroot/gentoo-x86/xfce-base/libxfce4ui/libxfce4ui-4.12.1.ebuild,v 1.1 2015/03/15 18:44:14 mgorny Exp $
+
+EAPI=5
+inherit xfconf
+
+DESCRIPTION="Unified widgets and session management libraries for the Xfce desktop environment"
+HOMEPAGE="http://www.xfce.org/projects/libxfce4"
+SRC_URI="mirror://xfce/src/xfce/${PN}/${PV%.*}/${P}.tar.bz2"
+
+LICENSE="LGPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sh ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~x86-freebsd ~x86-interix ~amd64-linux ~x86-linux ~x86-solaris"
+IUSE="debug glade gtk3 startup-notification"
+
+RDEPEND=">=dev-libs/glib-2.30:2=
+	>=x11-libs/gtk+-2.24:2=
+	x11-libs/libX11:=
+	x11-libs/libICE:=
+	x11-libs/libSM:=
+	>=xfce-base/libxfce4util-4.12:=
+	>=xfce-base/xfconf-4.12:=
+	glade? ( dev-util/glade:3= )
+	gtk3? ( >=x11-libs/gtk+-3.2:3= )
+	startup-notification? ( x11-libs/startup-notification:= )
+	!xfce-base/xfce-utils"
+DEPEND="${RDEPEND}
+	dev-lang/perl
+	dev-util/intltool
+	sys-devel/gettext
+	virtual/pkgconfig"
+
+pkg_setup() {
+	XFCONF=(
+		$(use_enable startup-notification)
+		$(use_enable glade gladeui)
+		$(use_enable gtk3)
+		$(xfconf_use_debug)
+		--with-vendor-info=Gentoo
+		--with-html-dir="${EPREFIX}"/usr/share/doc/${PF}/html
+		)
+
+	[[ ${CHOST} == *-darwin* ]] && XFCONF+=( --disable-visibility ) #366857
+
+	DOCS=( AUTHORS ChangeLog NEWS README THANKS TODO )
+}

--- a/xfce-base/libxfce4ui/metadata.xml
+++ b/xfce-base/libxfce4ui/metadata.xml
@@ -4,5 +4,6 @@
   <herd>xfce</herd>
   <use>
     <flag name='glade'>Build support for Glade 3's GtkBuilder implementation</flag>
+    <flag name='gtk3'>Enable GTK+3 support</flag> 
   </use>
 </pkgmetadata>

--- a/xfce-base/xfce4-appfinder/metadata.xml
+++ b/xfce-base/xfce4-appfinder/metadata.xml
@@ -2,4 +2,7 @@
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
   <herd>xfce</herd>
+  <use>
+    <flag name='gtk3'>Enable GTK+3 support</flag>
+  </use>
 </pkgmetadata>

--- a/xfce-base/xfce4-appfinder/xfce4-appfinder-4.12.0-r1.ebuild
+++ b/xfce-base/xfce4-appfinder/xfce4-appfinder-4.12.0-r1.ebuild
@@ -1,0 +1,37 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Header: /var/cvsroot/gentoo-x86/xfce-base/xfce4-appfinder/xfce4-appfinder-4.12.0.ebuild,v 1.1 2015/03/08 15:06:39 mgorny Exp $
+
+EAPI=5
+inherit xfconf
+
+DESCRIPTION="A tool to find and launch installed applications for the Xfce desktop environment"
+HOMEPAGE="http://www.xfce.org/projects/"
+SRC_URI="mirror://xfce/src/xfce/${PN}/${PV%.*}/${P}.tar.bz2"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~x86-freebsd ~x86-interix ~amd64-linux ~x86-linux ~x86-solaris"
+IUSE="debug gtk3"
+
+RDEPEND=">=dev-libs/dbus-glib-0.100
+	>=dev-libs/glib-2.30
+	gtk3? ( >=x11-libs/gtk+-3.2:3 )
+	>=xfce-base/garcon-0.3
+	>=xfce-base/libxfce4util-4.11
+	>=xfce-base/libxfce4ui-4.11
+	>=xfce-base/xfconf-4.10
+	!xfce-base/xfce-utils"
+DEPEND="${RDEPEND}
+	dev-util/intltool
+	sys-devel/gettext
+	virtual/pkgconfig"
+
+pkg_setup() {
+	XFCONF=(
+		$(use_enable gtk3)
+		$(xfconf_use_debug)
+		)
+
+	DOCS=( AUTHORS ChangeLog NEWS )
+}

--- a/xfce-base/xfce4-panel/metadata.xml
+++ b/xfce-base/xfce4-panel/metadata.xml
@@ -2,4 +2,7 @@
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
   <herd>xfce</herd>
+  <use>
+    <flag name='gtk3'>Enable GTK+3 support</flag>
+  </use>
 </pkgmetadata>

--- a/xfce-base/xfce4-panel/xfce4-panel-4.12.0-r1.ebuild
+++ b/xfce-base/xfce4-panel/xfce4-panel-4.12.0-r1.ebuild
@@ -1,0 +1,44 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Header: /var/cvsroot/gentoo-x86/xfce-base/xfce4-panel/xfce4-panel-4.12.0.ebuild,v 1.3 2015/04/15 07:47:08 mgorny Exp $
+
+EAPI=5
+inherit xfconf
+
+DESCRIPTION="Panel for the Xfce desktop environment"
+HOMEPAGE="http://www.xfce.org/projects/"
+SRC_URI="mirror://xfce/src/xfce/${PN}/${PV%.*}/${P}.tar.bz2"
+
+LICENSE="GPL-2 LGPL-2.1"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86 ~x86-fbsd ~x86-freebsd ~x86-interix ~amd64-linux ~x86-linux ~x86-solaris"
+IUSE="debug gtk3"
+
+RDEPEND=">=dev-libs/dbus-glib-0.100
+	>=dev-libs/glib-2.24
+	>=x11-libs/cairo-1
+	>=x11-libs/gtk+-2.20:2
+	gtk3? ( >=x11-libs/gtk+-3.2:3 )
+	x11-libs/libX11
+	>=x11-libs/libwnck-2.31:1
+	>=xfce-base/exo-0.8
+	>=xfce-base/garcon-0.3
+	>=xfce-base/libxfce4ui-4.11
+	>=xfce-base/libxfce4util-4.11
+	>=xfce-base/xfconf-4.10"
+DEPEND="${RDEPEND}
+	dev-lang/perl
+	dev-util/intltool
+	sys-devel/gettext
+	virtual/pkgconfig"
+
+pkg_setup() {
+	XFCONF=(
+		--docdir="${EPREFIX}"/usr/share/doc/${PF}
+		$(use_enable gtk3)
+		$(xfconf_use_debug)
+		--with-html-dir="${EPREFIX}"/usr/share/doc/${PF}/html
+		)
+
+	DOCS=( AUTHORS ChangeLog NEWS THANKS )
+}

--- a/xfce-extra/xfce4-indicator-plugin/xfce4-indicator-plugin-2.3.3.ebuild
+++ b/xfce-extra/xfce4-indicator-plugin/xfce4-indicator-plugin-2.3.3.ebuild
@@ -17,9 +17,9 @@ IUSE="debug"
 RDEPEND=">=dev-libs/libindicator-12.10.1:3=
 	>=x11-libs/gtk+-3.6:3=
 	x11-libs/libX11:=
-	>=xfce-base/libxfce4ui-4.11:=
+	>=xfce-base/libxfce4ui-4.11:=[gtk3(+)]
 	>=xfce-base/libxfce4util-4.11:=
-	>=xfce-base/xfce4-panel-4.11:=
+	>=xfce-base/xfce4-panel-4.11:=[gtk3(+)]
 	>=xfce-base/xfconf-4.10:="
 DEPEND="${RDEPEND}
 	dev-util/intltool

--- a/xfce-extra/xfce4-pulseaudio-plugin/xfce4-pulseaudio-plugin-0.2.2.ebuild
+++ b/xfce-extra/xfce4-pulseaudio-plugin/xfce4-pulseaudio-plugin-0.2.2.ebuild
@@ -17,9 +17,9 @@ IUSE="debug keybinder"
 RDEPEND=">=dev-libs/glib-2.24.0:=
 	media-sound/pulseaudio:=
 	>=x11-libs/gtk+-3.6.0:3=
-	>=xfce-base/libxfce4ui-4.11.0:=
+	>=xfce-base/libxfce4ui-4.11.0:=[gtk3(+)]
 	>=xfce-base/libxfce4util-4.9.0:=
-	>=xfce-base/xfce4-panel-4.11.0:=
+	>=xfce-base/xfce4-panel-4.11.0:=[gtk3(+)]
 	>=xfce-base/xfconf-4.6.0:=
 	keybinder? ( dev-libs/keybinder:3= )"
 DEPEND="${RDEPEND}


### PR DESCRIPTION
It's now possible to build xfce4-meta using only GTK2 libs. I've included the garcon 0.4 ebuild to support just that, 0.5 has a dependency on GTK3.

I've checked the revdeps for gtk3 support and only these 3 (garcon, indicator and pulseaudio plugin) have problems with non-gtk3 enabled build.
