### PR TITLE
linux-info.eclass: force exporting CONFIG_CHECK variable to global scope

### DIFF
--- a/eclass/linux-info.eclass
+++ b/eclass/linux-info.eclass
@@ -912,6 +912,8 @@ linux-info_pkg_setup() {
 	fi
 
 	if [ -n "${CONFIG_CHECK}" ]; then
+		# CONFIG_CHECK is re-declared here to ensure that this variable will be
+		# available in environment.bz2
 		declare -g CONFIG_CHECK="${CONFIG_CHECK}"
 		check_extra_config
 	fi

--- a/eclass/linux-info.eclass
+++ b/eclass/linux-info.eclass
@@ -680,6 +680,10 @@ check_modules_supported() {
 # It checks the kernel config options specified by CONFIG_CHECK. It dies only when a required config option (i.e.
 # the prefix ~ is not used) doesn't satisfy the directive.
 check_extra_config() {
+	# CONFIG_CHECK is re-declared here to ensure that this variable will be
+	# available in environment.bz2
+	declare -g CONFIG_CHECK="${CONFIG_CHECK}"
+
 	local config negate die error reworkmodulenames
 	local soft_errors_count=0 hard_errors_count=0 config_required=0
 	# store the value of the QA check, because otherwise we won't catch usages
@@ -911,10 +915,5 @@ linux-info_pkg_setup() {
 		fi
 	fi
 
-	if [ -n "${CONFIG_CHECK}" ]; then
-		# CONFIG_CHECK is re-declared here to ensure that this variable will be
-		# available in environment.bz2
-		declare -g CONFIG_CHECK="${CONFIG_CHECK}"
-		check_extra_config
-	fi
+	[ -n "${CONFIG_CHECK}" ] && check_extra_config;
 }

--- a/eclass/linux-info.eclass
+++ b/eclass/linux-info.eclass
@@ -911,5 +911,8 @@ linux-info_pkg_setup() {
 		fi
 	fi
 
-	[ -n "${CONFIG_CHECK}" ] && CONFIG_CHECK="${CONFIG_CHECK}" check_extra_config;
+	if [ -n "${CONFIG_CHECK}" ]; then
+		declare -g CONFIG_CHECK="${CONFIG_CHECK}"
+		check_extra_config
+	fi
 }

--- a/eclass/linux-info.eclass
+++ b/eclass/linux-info.eclass
@@ -911,5 +911,5 @@ linux-info_pkg_setup() {
 		fi
 	fi
 
-	[ -n "${CONFIG_CHECK}" ] && check_extra_config;
+	[ -n "${CONFIG_CHECK}" ] && CONFIG_CHECK="${CONFIG_CHECK}" check_extra_config;
 }


### PR DESCRIPTION
Hi all,

While writing a script which do some sanity checks for installed packages with kernel flag dependencies I found that some ebuilds define `CONFIG_CHECK` in `local` scope. This makes analysis of `/var/db/pkg/*/environment.bz2` more tricky because of missing `declare CONFIG_CHECK` record.
