### PR TITLE
games-util/xboxdrv: add dbus configuration, systemd support

### DIFF
--- a/games-util/xboxdrv/files/org.seul.Xboxdrv.conf
+++ b/games-util/xboxdrv/files/org.seul.Xboxdrv.conf
@@ -1,0 +1,7 @@
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+  <policy context="default">
+    <allow own="org.seul.Xboxdrv"/>
+  </policy>
+</busconfig>

--- a/games-util/xboxdrv/files/xboxdrv.service
+++ b/games-util/xboxdrv/files/xboxdrv.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Userspace Xbox 360 Controller driver
+BindsTo=sys-subsystem-usb-xbox-controller0.device
+After=sys-subsystem-usb-xbox-controller0.device
+
+[Service]
+BusName=org.seul.Xboxdrv
+ExecStart=/usr/bin/xboxdrv --silent --daemon
+KillSignal=SIGINT
+# xboxdrv can not stop gracefully if controller gets unplugged
+TimeoutStopSec=2
+
+[Install]
+WantedBy=multi-user.target

--- a/games-util/xboxdrv/files/xboxdrv.udev-rules
+++ b/games-util/xboxdrv/files/xboxdrv.udev-rules
@@ -1,0 +1,5 @@
+SUBSYSTEM=="usb", ACTION=="add",\
+	ENV{ID_MODEL_FROM_DATABASE}=="Xbox*Controller|Xbox*Controller S",\
+	TAG+="systemd",\
+	ENV{SYSTEMD_ALIAS}="/sys/subsystem/usb/xbox/controller$number",\
+	ENV{SYSTEMD_WANTS}+="xboxdrv.service"

--- a/games-util/xboxdrv/xboxdrv-0.8.5-r2.ebuild
+++ b/games-util/xboxdrv/xboxdrv-0.8.5-r2.ebuild
@@ -1,0 +1,59 @@
+# Copyright 1999-2013 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Header: /var/cvsroot/gentoo-x86/games-util/xboxdrv/xboxdrv-0.8.5-r1.ebuild,v 1.4 2013/10/14 22:08:04 tristan Exp $
+
+EAPI=5
+inherit base linux-info scons-utils toolchain-funcs systemd udev
+
+MY_P=${PN}-linux-${PV}
+DESCRIPTION="Userspace Xbox 360 Controller driver"
+HOMEPAGE="http://pingus.seul.org/~grumbel/xboxdrv/"
+SRC_URI="http://pingus.seul.org/~grumbel/xboxdrv/${MY_P}.tar.bz2"
+
+LICENSE="GPL-3"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE=""
+
+RDEPEND="dev-libs/boost
+	virtual/udev
+	sys-apps/dbus
+	dev-libs/glib:2
+	virtual/libusb:1
+	x11-libs/libX11"
+DEPEND="${RDEPEND}
+	virtual/pkgconfig"
+
+S=${WORKDIR}/${MY_P}
+
+CONFIG_CHECK="~INPUT_EVDEV ~INPUT_JOYDEV ~INPUT_UINPUT ~!JOYSTICK_XPAD"
+PATCHES=( "${FILESDIR}"/${P}-scons.patch )
+
+src_compile() {
+	escons \
+		BUILD=custom \
+		CXX="$(tc-getCXX)" \
+		AR="$(tc-getAR)" \
+		RANLIB="$(tc-getRANLIB)" \
+		CXXFLAGS="-Wall ${CXXFLAGS}" \
+		LINKFLAGS="${LDFLAGS}"
+}
+
+src_install() {
+	dobin xboxdrv
+	doman doc/xboxdrv.1
+	dodoc AUTHORS NEWS PROTOCOL README TODO
+
+	newinitd "${FILESDIR}"/xboxdrv.initd xboxdrv
+	newconfd "${FILESDIR}"/xboxdrv.confd xboxdrv
+
+	insinto /etc/dbus-1/system.d/
+	doins "${FILESDIR}/org.seul.Xboxdrv.conf"
+
+	udev_newrules "${FILESDIR}"/xboxdrv.udev-rules 99-xbox-controller.rules
+	systemd_dounit "${FILESDIR}"/xboxdrv.service
+}
+
+pkg_postinst() {
+	udev_reload
+}


### PR DESCRIPTION
Added DBus configuration file (bug https://bugs.gentoo.org/show_bug.cgi?id=481572)
Added systemd unit, udev rules (bug https://bugs.gentoo.org/show_bug.cgi?id=544752)
