### PR TITLE
nfs.initd - fix typo (useless empty space)

### DIFF
--- a/net-fs/nfs-utils/files/nfs.initd
+++ b/net-fs/nfs-utils/files/nfs.initd
@@ -11,8 +11,8 @@ restarting=no
 
 # The binary locations
 exportfs=/usr/sbin/exportfs
-  mountd=/usr/sbin/rpc.mountd
-    nfsd=/usr/sbin/rpc.nfsd
+mountd=/usr/sbin/rpc.mountd
+nfsd=/usr/sbin/rpc.nfsd
 smnotify=/usr/sbin/sm-notify
 
 depend() {


### PR DESCRIPTION
This is a tiny fix for nfs.initd. It kills some empty space in the file. I also haven't created an bug for this (bug i can still create one if needed) :)
