### PR TITLE
x11-wm/notion version bump

### DIFF
--- a/x11-wm/notion/notion-3_p2015061300.ebuild
+++ b/x11-wm/notion/notion-3_p2015061300.ebuild
@@ -24,7 +24,7 @@ RDEPEND=">=dev-lang/lua-5.1
 	xrandr? ( x11-libs/libXrandr )"
 
 DEPEND="${RDEPEND}
-		virtual/pkgconfig"
+	virtual/pkgconfig"
 
 S=${WORKDIR}/${P/_p/-}
 
@@ -41,8 +41,10 @@ src_prepare() {
 		-e "s:^\(VARDIR=\).*$:\1${ROOT}var/cache/${PN}:" \
 		-e "s:^\(X11_PREFIX=\).*:\1\$(PREFIX)/usr:" \
 		-i system-autodetect.mk || die
+
 	sed -e 's/gcc/$(CC)/g' \
 		-i ioncore/Makefile || die
+
 	export STRIPPROG=true
 
 	tc-export CC

--- a/x11-wm/notion/notion-3_p2015061300.ebuild
+++ b/x11-wm/notion/notion-3_p2015061300.ebuild
@@ -1,20 +1,18 @@
 # Copyright 1999-2014 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Header: /var/cvsroot/gentoo-x86/x11-wm/notion/notion-9999.ebuild,v 1.8 2014/05/25 13:01:33 jer Exp $
+# $Header: /var/cvsroot/gentoo-x86/x11-wm/notion/notion-3_p2013030200.ebuild,v 1.4 2014/05/25 13:01:33 jer Exp $
 
 EAPI=5
 
-EGIT_REPO_URI="git://notion.git.sourceforge.net/gitroot/notion/notion"
-EGIT_HAS_SUBMODULES="1"
-
-inherit eutils git-2 multilib toolchain-funcs
+inherit eutils multilib toolchain-funcs
 
 DESCRIPTION="Notion is a tiling, tabbed window manager for the X window system"
 HOMEPAGE="http://notion.sourceforge.net"
+SRC_URI="https://github.com/raboof/${PN}/archive/${PV/_p/-}.tar.gz"
 
 LICENSE="LGPL-2.1"
 SLOT="0"
-KEYWORDS=""
+KEYWORDS="~amd64 ~x86"
 IUSE="nls xinerama +xrandr"
 
 RDEPEND=">=dev-lang/lua-5.1
@@ -28,18 +26,20 @@ RDEPEND=">=dev-lang/lua-5.1
 DEPEND="${RDEPEND}
 		virtual/pkgconfig"
 
+S=${WORKDIR}/${P/_p/-}
+
 src_prepare() {
 	sed -e "/^CFLAGS=/s:=:+=:" \
-                -e "/^CFLAGS/{s:-Os:: ; s:-g::}" \
-                -e "/^LDFLAGS=/{s:=:+=: ; s:-Wl,--as-needed::}" \
-                -e "/^CC=/s:=:?=:" \
-                -e "s:^\(PREFIX=\).*$:\1${ROOT}usr:" \
-                -e "s:^\(ETCDIR=\).*$:\1${ROOT}etc/notion:" \
-                -e "s:^\(LIBDIR=\).*:\1\$(PREFIX)/$(get_libdir):" \
-                -e "s:^\(DOCDIR=\).*:\1\$(PREFIX)/share/doc/${PF}:" \
-                -e "s:^\(LUA_DIR=\).*$:\1\$(PREFIX)/usr:" \
-                -e "s:^\(VARDIR=\).*$:\1${ROOT}var/cache/${PN}:" \
-                -e "s:^\(X11_PREFIX=\).*:\1\$(PREFIX)/usr:" \
+		-e "/^CFLAGS/{s:-Os:: ; s:-g::}" \
+		-e "/^LDFLAGS=/{s:=:+=: ; s:-Wl,--as-needed::}" \
+		-e "/^CC=/s:=:?=:" \
+		-e "s:^\(PREFIX=\).*$:\1${ROOT}usr:" \
+		-e "s:^\(ETCDIR=\).*$:\1${ROOT}etc/notion:" \
+		-e "s:^\(LIBDIR=\).*:\1\$(PREFIX)/$(get_libdir):" \
+		-e "s:^\(DOCDIR=\).*:\1\$(PREFIX)/share/doc/${PF}:" \
+		-e "s:^\(LUA_DIR=\).*$:\1\$(PREFIX)/usr:" \
+		-e "s:^\(VARDIR=\).*$:\1${ROOT}var/cache/${PN}:" \
+		-e "s:^\(X11_PREFIX=\).*:\1\$(PREFIX)/usr:" \
 		-i system-autodetect.mk || die
 	sed -e 's/gcc/$(CC)/g' \
 		-i ioncore/Makefile || die

--- a/x11-wm/notion/notion-9999.ebuild
+++ b/x11-wm/notion/notion-9999.ebuild
@@ -26,23 +26,25 @@ RDEPEND=">=dev-lang/lua-5.1
 	xrandr? ( x11-libs/libXrandr )"
 
 DEPEND="${RDEPEND}
-		virtual/pkgconfig"
+	virtual/pkgconfig"
 
 src_prepare() {
 	sed -e "/^CFLAGS=/s:=:+=:" \
-                -e "/^CFLAGS/{s:-Os:: ; s:-g::}" \
-                -e "/^LDFLAGS=/{s:=:+=: ; s:-Wl,--as-needed::}" \
-                -e "/^CC=/s:=:?=:" \
-                -e "s:^\(PREFIX=\).*$:\1${ROOT}usr:" \
-                -e "s:^\(ETCDIR=\).*$:\1${ROOT}etc/notion:" \
-                -e "s:^\(LIBDIR=\).*:\1\$(PREFIX)/$(get_libdir):" \
-                -e "s:^\(DOCDIR=\).*:\1\$(PREFIX)/share/doc/${PF}:" \
-                -e "s:^\(LUA_DIR=\).*$:\1\$(PREFIX)/usr:" \
-                -e "s:^\(VARDIR=\).*$:\1${ROOT}var/cache/${PN}:" \
-                -e "s:^\(X11_PREFIX=\).*:\1\$(PREFIX)/usr:" \
+		-e "/^CFLAGS/{s:-Os:: ; s:-g::}" \
+		-e "/^LDFLAGS=/{s:=:+=: ; s:-Wl,--as-needed::}" \
+		-e "/^CC=/s:=:?=:" \
+		-e "s:^\(PREFIX=\).*$:\1${ROOT}usr:" \
+		-e "s:^\(ETCDIR=\).*$:\1${ROOT}etc/notion:" \
+		-e "s:^\(LIBDIR=\).*:\1\$(PREFIX)/$(get_libdir):" \
+		-e "s:^\(DOCDIR=\).*:\1\$(PREFIX)/share/doc/${PF}:" \
+		-e "s:^\(LUA_DIR=\).*$:\1\$(PREFIX)/usr:" \
+		-e "s:^\(VARDIR=\).*$:\1${ROOT}var/cache/${PN}:" \
+		-e "s:^\(X11_PREFIX=\).*:\1\$(PREFIX)/usr:" \
 		-i system-autodetect.mk || die
+
 	sed -e 's/gcc/$(CC)/g' \
 		-i ioncore/Makefile || die
+
 	export STRIPPROG=true
 
 	tc-export CC


### PR DESCRIPTION
version bump for the notion window manager. The 9999 ebuild has been updated as well. Development has switched to github from sourceforge.
