### PR TITLE
Fix URL for mirror with metadata.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ New resources:
 1. [cgit for offical repo](https://gitweb.gentoo.org/repo/gentoo.git),
 2. [GitHub mirror](https://github.com/gentoo/gentoo),
 3. [GitHub mirror with pre-generated metadata
-   cache](https://github.com/gentoo-mirrors/gentoo).
+   cache](https://github.com/gentoo-mirror/gentoo).
 
 For development, please use either 1. or 2. You can submit Pull Requests
 either via mail (`git request-pull`) or using GitHub mirror.


### PR DESCRIPTION
The URL of 3. is wrong (an 's' too much), please fix
